### PR TITLE
add .Content to layout file

### DIFF
--- a/layouts/_default/decap-cms.html
+++ b/layouts/_default/decap-cms.html
@@ -11,5 +11,6 @@
   </head>
   <body>
     <script src="{{ default `https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js` site.Params.decap_cms.js_url }}"></script>
+    {{ safeHTML | .Content }}
   </body>
 </html>


### PR DESCRIPTION
In your implementation there is no clear way to [creating custom previews](https://decapcms.org/docs/customization/) or [registering custom widgets](https://decapcms.org/docs/custom-widgets/) with Decap CMS.

This one-line add of `{{ safeHTML | .Content }}` allows one to embed such things in the `content/admin/index.html` file and then it is injected correctly.