### PR TITLE
feat: add the decap-cms/hooks/body-end hook for customizing Decap CMS

### DIFF
--- a/layouts/_default/decap-cms.html
+++ b/layouts/_default/decap-cms.html
@@ -11,5 +11,6 @@
   </head>
   <body>
     <script src="{{ default `https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js` site.Params.decap_cms.js_url }}"></script>
+    {{ partialCached "decap-cms/hooks/body-end" . }}
   </body>
 </html>


### PR DESCRIPTION
Replaces and closes #30

This PR adds a hook for customizing the Decap CMS, take `registerPreviewStyle` as an example.

To use this hook, you'll need to create the `layouts/partials/decap-cms/hooks/body-end.html` file on your site root.

```scss
// assets/main.scss
h1, h2, h3, h4, h5, h6 {
  color: red;
}
```

```go
// layouts/partials/decap-cms/hooks/body-end.html
<script>
  {{- $css := resources.Get "main.scss" | toCSS }}
  CMS.registerPreviewStyle('{{ $css.RelPermalink }}');
</script>
```

If your theme using prebuilt styles (not using Hugo pipes), you can register it directly.

```go
// layouts/partials/decap-cms/hooks/body-end.html
<script>
  CMS.registerPreviewStyle('{{ "/css/main.css" | relURL }}');
</script>
```