### PR TITLE
feat: allow adding custom preview styles

### DIFF
--- a/assets/decap-cms/init.js.tmpl
+++ b/assets/decap-cms/init.js.tmpl
@@ -1,3 +1,7 @@
+{{/* Register preview styles. */}}
+{{- $css := resources.Get "decap-cms/scss/index.scss" }}
+{{- $css = $css | toCSS (dict "targetPath" "css/decap-cms.css" "outputStyle" (cond hugo.IsProduction "compressed" "")) }}
+{{- printf `CMS.registerPreviewStyle("%s");` $css.Permalink }}
 {{- $widgets := slice }}
 {{- range resources.Match "decap-cms/widgets/*.js" }}
   {{- $name := replace .Name "decap-cms/widgets/" "" }}

--- a/assets/decap-cms/scss/index.scss
+++ b/assets/decap-cms/scss/index.scss
@@ -1,0 +1,1 @@
+@import "custom";


### PR DESCRIPTION
To register preview style, you should create the `assets/decap-cms/scss/_custom.scss` file.

```scss
h1 {
  color: red;
}
```