### PR TITLE
feat: fill i18n fields if enabled

### DIFF
--- a/layouts/_default/index.decapcmsconfig.yaml
+++ b/layouts/_default/index.decapcmsconfig.yaml
@@ -37,4 +37,16 @@
     {{- $config.Set "logo_url" . }}
   {{- end }}
 {{- end }}
+{{/* Fill i18n fields if enabled. */}}
+{{- with $config.Get "i18n" }}
+  {{- $i18n := . }}
+  {{- $locales := partialCached "decap-cms/functions/locales" . }}
+  {{- if not .locales }}
+    {{- $i18n = merge $i18n (dict "locales" $locales) }}
+  {{- end }}
+  {{- if not .default_locale }}
+    {{- $i18n = merge $i18n (dict "default_locale" (index $locales 0)) }}
+  {{- end }}
+  {{- $config.Set "i18n" $i18n }}
+{{- end }}
 {{- transform.Remarshal "yaml" $config.Values | safeHTML -}}

--- a/layouts/partials/decap-cms/functions/locale.html
+++ b/layouts/partials/decap-cms/functions/locale.html
@@ -1,12 +1,6 @@
-{{- $locales := dict
-  "zh-cn" "zh_Hans"
-  "zh-hans" "zh_Hans"
-  "zh-hant" "zh_Hant"
-  "zh-hk" "zh_Hant"
-  "zh-tw" "zh_Hant"
-}}
+{{- $map := partialCached "decap-cms/functions/locales-map" . }}
 {{- $locale := site.Language.LanguageCode }}
-{{- with index $locales $locale }}
+{{- with index $map $locale }}
   {{- $locale = . }}
 {{- end }}
 {{- return $locale }}

--- a/layouts/partials/decap-cms/functions/locales-map.html
+++ b/layouts/partials/decap-cms/functions/locales-map.html
@@ -1,0 +1,7 @@
+{{- return dict
+  "zh-cn" "zh_Hans"
+  "zh-hans" "zh_Hans"
+  "zh-hant" "zh_Hant"
+  "zh-hk" "zh_Hant"
+  "zh-tw" "zh_Hant"
+}}

--- a/layouts/partials/decap-cms/functions/locales.html
+++ b/layouts/partials/decap-cms/functions/locales.html
@@ -1,0 +1,10 @@
+{{- $map := partialCached "decap-cms/functions/locales-map" . }}
+{{- $locales := slice }}
+{{- range site.Languages }}
+  {{- with index $map .LanguageCode }}
+    {{- $locales = $locales | append . }}
+  {{- else }}
+    {{- $locales = $locales | append .LanguageCode }}
+  {{- end }}
+{{- end }}
+{{- return $locales }}


### PR DESCRIPTION
Closes #48 

This PR fills `i18n.locales` and `i18n.default_locale` if the `i18n` enabled to simplify configuration setup, with this, users don't need to specify those params.

```toml
params:
  decap_cms
      i18n:
        structure: multiple_files
        # locales: [en, zh-hans] # optional, will be resolved automatically.
        # default_locale: en # optional, will be resolved automatically.
```