### PR TITLE
feat: add the _preview_templates parameter

### DIFF
--- a/assets/decap-cms/init.js.tmpl
+++ b/assets/decap-cms/init.js.tmpl
@@ -5,6 +5,19 @@
 {{- range default slice site.Params.decap_cms.preview_styles }}
   {{- printf `CMS.registerPreviewStyle("%s");` (absURL .) }}
 {{- end }}
+{{/* Imports preview templates. */}}
+{{- $previewTemplates := newScratch }}
+{{- range $i, $pt := default slice site.Params.decap_cms._preview_templates }}
+  {{- if or (not .name) (not .collections) }}
+    {{- errorf "[decap-cms] preview template #%d missing required name or collections." $i }}
+  {{- end }}
+  {{- $name := .name }}
+  {{- $templateName := replaceRE `[-\/]` "_" $name | printf "%s_preview" }}
+  {{- if not ($previewTemplates.Get $templateName) }}
+    {{- printf `import { default as %s } from "./preview-templates/%s";` $templateName $name }}
+  {{- end }}
+  {{- $previewTemplates.Add $templateName .collections }}
+{{- end }}
 {{- $widgets := slice }}
 {{- range resources.Match "decap-cms/widgets/*.js" }}
   {{- $name := replace .Name "decap-cms/widgets/" "" }}
@@ -32,4 +45,10 @@ const emptySchema = {};
 {{- end }}
 {{- range $editorComponents }}
   {{- printf "CMS.registerEditorComponent(%s);" . }}
+{{- end }}
+{{/* Registers preview templates. */}}
+{{- range $name, $collections := $previewTemplates.Values }}
+  {{- range $collections }}
+    {{- printf "CMS.registerPreviewTemplate('%s', %s);" . $name }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
To register preview templates:
1. Save preview templates in "assets/decap-cms/preview-templates" folders, it's recommended using a special subfolder, such as app, site or custom. The preview template MUST export a default class as follows.

```typescript
// assets/decap-cms/preview-templates/app/title.ts
export default createClass({
  render: function () {
    return h('div', {}, this.props.entry.getIn(['data', 'title']));
  }
})
```

2. Then configure the preview templates for collections.

```
params:
  decap_cms:
    _preview_templates:
      - name: 'app/title' # the filename (without extension) of preview template.
        collections: ['news', 'posts'] # which collections will apply this preview template.
```

Closes #55