### PR TITLE
feat: add the collection _weight parameter for sorting

### DIFF
--- a/layouts/partials/decap-cms/functions/format.html
+++ b/layouts/partials/decap-cms/functions/format.html
@@ -1,9 +1,13 @@
 {{/* Format the configurations:
   1. Remove internal used parameters.
   2. Trasnlate labels.
+  3. Sort collections.
 */}}
 {{- $config := . }}
 {{- $collections := default slice ($config.Get "collections") }}
+{{- $sortedCollections := sort (default slice (where $collections "_weight" "ne" nil)) "_weight" }}
+{{- $unsortedCollections := sort (default slice (where $collections "_weight" nil)) "name" }}
+{{- $collections = $sortedCollections | append $unsortedCollections }}
 {{- $config.Set "collections" slice }}
 {{- range $collections }}
   {{- $tmp := newScratch }}
@@ -49,3 +53,4 @@
   {{- end }}
   {{- $config.Add "collections" (slice ($tmp.Get "c")) }}
 {{- end }}
+{{- $config.Set "collections" $collections }}


### PR DESCRIPTION
Fixes #51 

```yaml
params:
  decap_cms:
    collections:
      bar:
        _weight: 2
      foo:
        _weight: 1
```

`foo` will get higher priority.