### PR TITLE
feat: translate collection labels

### DIFF
--- a/layouts/partials/decap-cms/functions/format.html
+++ b/layouts/partials/decap-cms/functions/format.html
@@ -15,10 +15,13 @@
   {{- range $name, $value := . }}
     {{- if hasPrefix $name "_" }}
       {{- $tmp.DeleteInMap "c" $name }}
+    {{- else if in (slice "label" "label_singular") $name }}
+      {{- $label := partial "decap-cms/functions/translate-label" $value }}
+      {{- $tmp.SetInMap "c" $name $label }}
     {{- else if eq $name "meta" }}
       {{- $meta := $value }}
       {{- with index $meta "path" }}
-        {{- $pathLabel := partial "decap-cms/functions/translate-label" .label }}
+        {{- $pathLabel := partial "decap-cms/functions/translate-field-label" .label }}
         {{- $meta = merge $meta (dict "path" (merge . (dict "label" $pathLabel))) }}
         {{- $tmp.SetInMap "c" "meta" $meta }}
       {{- end }}
@@ -31,15 +34,15 @@
           {{- if hasPrefix $fName "_" }}
             {{- $tmp2.DeleteInMap "f" $fName }}
           {{- else if eq $fName "label" }}
-            {{- $label := partial "decap-cms/functions/translate-label" $fValue }}
+            {{- $label := partial "decap-cms/functions/translate-field-label" $fValue }}
             {{- $tmp2.SetInMap "f" "label" $label }}
           {{- else if eq $fName "field" }}
-            {{- $childLabel := partial "decap-cms/functions/translate-label" $fValue.label }}
+            {{- $childLabel := partial "decap-cms/functions/translate-field-label" $fValue.label }}
             {{- $tmp2.SetInMap "f" "field" (merge $fValue (dict "label" $childLabel)) }}
           {{- else if eq $fName "fields" }}
             {{- $children := slice }}
             {{- range $fValue }}
-              {{- $childLabel := partial "decap-cms/functions/translate-label" .label }}
+              {{- $childLabel := partial "decap-cms/functions/translate-field-label" .label }}
               {{- $child := . }}
               {{- $children = $children | append (merge . (dict "label" $childLabel)) }}
             {{- end }}

--- a/layouts/partials/decap-cms/functions/translate-field-label.html
+++ b/layouts/partials/decap-cms/functions/translate-field-label.html
@@ -1,0 +1,1 @@
+{{ return default . (printf "cms_field_label_%s" (replace (lower .) " " "_") | i18n) }}

--- a/layouts/partials/decap-cms/functions/translate-label.html
+++ b/layouts/partials/decap-cms/functions/translate-label.html
@@ -1,1 +1,1 @@
-{{ return default . (printf "cms_field_label_%s" (replace (lower .) " " "_") | i18n) }}
+{{ return default . (printf "cms_label_%s" (replace (lower .) " " "_") | i18n) }}


### PR DESCRIPTION
Let's say there is a collection:

```yaml
params:
  decap_cms:
    collections:
      hello:
        label: Hello
```

To translate the `Hello` in other languages, such as Simplified Chinese (`zh-hans`), create `i18n/zh-hans.toml` and use `cms_label_hello` (lowercase) as the key.

```toml
[cms_label_hello]
other = "你好"
```