### PR TITLE
feat: allow loading module scoped preview styles

### DIFF
--- a/assets/decap-cms/init.js.tmpl
+++ b/assets/decap-cms/init.js.tmpl
@@ -1,6 +1,6 @@
 {{- $ctx := . }}
 {{/* Register preview styles. */}}
-{{- $css := resources.Get "decap-cms/scss/index.scss" }}
+{{- $css := resources.Get "decap-cms/scss/index.scss.tmpl" | resources.ExecuteAsTemplate "decap-cms/scss/index.scss" $ctx }}
 {{- $css = $css | toCSS (dict "targetPath" "css/decap-cms.css" "outputStyle" (cond hugo.IsProduction "compressed" "")) }}
 {{- range $name, $partial := default slice site.Params.decap_cms._preview_style_partials }}
   {{- if not $partial.path }}

--- a/assets/decap-cms/scss/index.scss
+++ b/assets/decap-cms/scss/index.scss
@@ -1,1 +1,0 @@
-@import "custom";

--- a/assets/decap-cms/scss/index.scss.tmpl
+++ b/assets/decap-cms/scss/index.scss.tmpl
@@ -1,0 +1,4 @@
+{{- range default slice (resources.Match "decap-cms/scss/**/*.scss") }}
+  {{- replace .Name "decap-cms/scss/" "" | printf `@import "%s";` }}
+{{- end }}
+@import "custom";


### PR DESCRIPTION
With this, `assets/decap-cms/scss/**/*.scss` will be loaded automatically.