### PR TITLE
fix: rename js_url with _js_url

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -10,7 +10,7 @@ notAlternative = true
 mediaType = "application/yaml"
 
 [params.decap_cms]
-js_url = ""
+_js_url = ""
 # local_backend = false
 publish_mode = "editorial_workflow"
 media_folder = "static/images/uploads"

--- a/layouts/partials/decap-cms/script.html
+++ b/layouts/partials/decap-cms/script.html
@@ -1,4 +1,10 @@
+{{- $jsURL := default "" site.Params.decap_cms._js_url }}
+{{/* TODO: remove js_url parameter. */}}
 {{- with site.Params.decap_cms.js_url }}
+  {{- warnf "[decap-cms] js_url is deprecated, use _js_url instead." }}
+  {{- $jsURL = . }}
+{{- end }}
+{{- with $jsURL }}
   <script src="{{ . }}"></script>
 {{- else }}
   {{- $js := resources.Get "decap-cms/index.js" }}


### PR DESCRIPTION
`decap_cms.js_url` still work, but will be removed in future version.