### PR TITLE
feat: add _disable parameter for disabling fields

### DIFF
--- a/layouts/partials/decap-cms/functions/deep-merge.html
+++ b/layouts/partials/decap-cms/functions/deep-merge.html
@@ -48,6 +48,16 @@
             {{- $fieldName := .name }}
             {{- $field := partial "decap-cms/functions/dict2scratch" . }}
             {{- $currentWeight := $field.Get "_weight" }}
+            {{/* Ignore disabled field. */}}
+            {{- if default false ($field.Get "_disable") }}
+              {{- if isset $values $fieldName }}
+                {{- $newValues := newScratch }}
+                {{- $newValues.Set "v" $values }}
+                {{- $newValues.DeleteInMap "v" $fieldName }}
+                {{- $values = $newValues.Get "v" }}
+              {{- end }}
+              {{- continue }}
+            {{- end }}
             {{- if isset $values $fieldName }}
               {{- with $currentWeight }}
                 {{/* Override the weight if presents and belongs to the last collection. */}}


### PR DESCRIPTION
We're able to define some extensible configs, but you may want to remove some of fields from it.

```yaml
params:
  decap_cms:
    _configs:
      foo:
        fields:
          - {name: title, label: Title, widget: string}
          - {name: description, label: Description, widget: string}
    collections:
      foobar:
        _extends:
          - foo
        fields:
          - {name: description, _disable: true}
          - {name: summary, label: Summary, widget: string}
```

The `foobar` extends `foo`, but replace the `description` with `summary` by setting `_disable` as `true` for specified field `name`.