### PR TITLE
fix: print a warning message if the DecapCMSConfig does not present in the home output

### DIFF
--- a/layouts/_default/decap-cms.html
+++ b/layouts/_default/decap-cms.html
@@ -7,6 +7,8 @@
     <title>{{ .Title }}</title>
     {{- with site.Home.OutputFormats.Get "DecapCMSConfig" }}
       <link href="{{ .RelPermalink }}" type="text/yaml" rel="cms-config-url" />
+    {{- else }}
+      {{- warnf "[decap-cms] please append %q into the %q output in configuration." "DecapCMSConfig" "home" }}
     {{- end }}
     {{ partialCached "decap-cms/hooks/head-end" . }}
   </head>


### PR DESCRIPTION
Related to #151.